### PR TITLE
fixed check for \n\n not allways done

### DIFF
--- a/lib/agi-server.js
+++ b/lib/agi-server.js
@@ -40,7 +40,7 @@ AGIConnection.prototype.handleData = function(data) {
     self.handler(data.trim());
   } else {
     this.buffer += data;
-    if (data.indexOf('\n\n') >= 0) {
+    if (this.buffer.indexOf('\n\n') >= 0) {
       // environment is sent
       var request = AGIChannel.parseBuffer(this.buffer);
       var channel = new AGIChannel(request, this.mapper);


### PR DESCRIPTION
hi. i observed that sometimes asterisk sends the second line feed in a separate package. in this cases i believe this implementation does not complete the initialisation of the call resulting in zombie channels. what's your take on it? 