### PR TITLE
channel emits 'hangup' event on hangup

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ Plays the specified `file`. Playback can be stopped using one of the (optional) 
 
 Hangs up the current channel.
 
+#### 2.3 Channel events
+
+* 'hangup'
+
+Emitted when the current channel is hung up.
 
 ## LICENSE
 

--- a/lib/agi-channel.js
+++ b/lib/agi-channel.js
@@ -81,6 +81,9 @@ var AGIChannel = function(request, mapper) {
 util.inherits(AGIChannel, events.EventEmitter);
 
 AGIChannel.prototype.handleReply = function(reply) {
+  if (reply == 'hangup') {
+    this.emit('hangup') ;
+  }
   if (this.callback) {
     if (reply == 'hangup') {
       this.callback('hangup');


### PR DESCRIPTION
This change causes the agi channel object to emit a hangup event when the channel is hung up.

The use case is when the AGI is waiting for something to happen elsewhere in the system, and needs to handle a hangup event as an exceptional case.  For example, the AGI has sent a push notification to a mobile application, and is waiting for an asynchronous reply before continuing.  The agi would continue when the asynchronous reply happens, or alternately send a cancellation push notification when the caller hangs up.

Contrived example:

    (function waitForHangup(cb) {
        someOtherEmitter.on('somethingElseHappens', cb) ;
        ch.once('hangup', () => {
            sendFailureNotification() ;
            cb() ;
        }) ;
    }).sync(null) ;

